### PR TITLE
Add overloads to CSharpFormatter.FormatParameter/FormatParameterList/FormatTypeName that accepts lock object for NullabilityInfoContext

### DIFF
--- a/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatTypeName.cs
+++ b/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatTypeName.cs
@@ -47,6 +47,23 @@ static partial class CSharpFormatter {
     bool withDeclaringTypeName = true,
     bool translateLanguagePrimitiveType = true
   )
+    => FormatTypeName(
+      f: f ?? throw new ArgumentNullException(nameof(f)),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      withDeclaringTypeName: withDeclaringTypeName,
+      translateLanguagePrimitiveType: translateLanguagePrimitiveType
+    );
+
+  public static string FormatTypeName(
+    this FieldInfo f,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool withDeclaringTypeName = true,
+    bool translateLanguagePrimitiveType = true
+  )
     => nullabilityInfoContext is null
       ? FormatTypeName(
         f: f,
@@ -55,7 +72,7 @@ static partial class CSharpFormatter {
         translateLanguagePrimitiveType: translateLanguagePrimitiveType
       )
       : FormatTypeNameWithNullabilityAnnotation(
-        nullabilityInfoContext.Create(f ?? throw new ArgumentNullException(nameof(f))),
+        target: nullabilityInfoContext.Create(f ?? throw new ArgumentNullException(nameof(f)), nullabilityInfoContextLockObject),
         builder: new(capacity: 32),
         options: new(
           AttributeProvider: f,
@@ -93,6 +110,23 @@ static partial class CSharpFormatter {
     bool withDeclaringTypeName = true,
     bool translateLanguagePrimitiveType = true
   )
+    => FormatTypeName(
+      p: p ?? throw new ArgumentNullException(nameof(p)),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      withDeclaringTypeName: withDeclaringTypeName,
+      translateLanguagePrimitiveType: translateLanguagePrimitiveType
+    );
+
+  public static string FormatTypeName(
+    this PropertyInfo p,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool withDeclaringTypeName = true,
+    bool translateLanguagePrimitiveType = true
+  )
     => nullabilityInfoContext is null
       ? FormatTypeName(
         p: p,
@@ -101,7 +135,7 @@ static partial class CSharpFormatter {
         translateLanguagePrimitiveType: translateLanguagePrimitiveType
       )
       : FormatTypeNameWithNullabilityAnnotation(
-        nullabilityInfoContext.Create(p ?? throw new ArgumentNullException(nameof(p))),
+        target: nullabilityInfoContext.Create(p ?? throw new ArgumentNullException(nameof(p)), nullabilityInfoContextLockObject),
         builder: new(capacity: 32),
         options: new(
           AttributeProvider: p,
@@ -139,6 +173,23 @@ static partial class CSharpFormatter {
     bool withDeclaringTypeName = true,
     bool translateLanguagePrimitiveType = true
   )
+    => FormatTypeName(
+      p: p ?? throw new ArgumentNullException(nameof(p)),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      withDeclaringTypeName: withDeclaringTypeName,
+      translateLanguagePrimitiveType: translateLanguagePrimitiveType
+    );
+
+  public static string FormatTypeName(
+    this ParameterInfo p,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool withDeclaringTypeName = true,
+    bool translateLanguagePrimitiveType = true
+  )
     => nullabilityInfoContext is null
       ? FormatTypeName(
         p: p,
@@ -147,7 +198,7 @@ static partial class CSharpFormatter {
         translateLanguagePrimitiveType: translateLanguagePrimitiveType
       )
       : FormatTypeNameWithNullabilityAnnotation(
-        nullabilityInfoContext.Create(p ?? throw new ArgumentNullException(nameof(p))),
+        target: nullabilityInfoContext.Create(p ?? throw new ArgumentNullException(nameof(p)), nullabilityInfoContextLockObject),
         builder: new(capacity: 32),
         options: new(
           AttributeProvider: p,
@@ -185,6 +236,23 @@ static partial class CSharpFormatter {
     bool withDeclaringTypeName = true,
     bool translateLanguagePrimitiveType = true
   )
+    => FormatTypeName(
+      ev: ev,
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      withDeclaringTypeName: withDeclaringTypeName,
+      translateLanguagePrimitiveType: translateLanguagePrimitiveType
+    );
+
+  public static string FormatTypeName(
+    this EventInfo ev,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool withDeclaringTypeName = true,
+    bool translateLanguagePrimitiveType = true
+  )
     => nullabilityInfoContext is null
       ? FormatTypeName(
         ev: ev,
@@ -193,7 +261,7 @@ static partial class CSharpFormatter {
         translateLanguagePrimitiveType: translateLanguagePrimitiveType
       )
       : FormatTypeNameWithNullabilityAnnotation(
-        nullabilityInfoContext.Create(ev ?? throw new ArgumentNullException(nameof(ev))),
+        target: nullabilityInfoContext.Create(ev ?? throw new ArgumentNullException(nameof(ev)), nullabilityInfoContextLockObject),
         builder: new(capacity: 32),
         options: new(
           AttributeProvider: ev,

--- a/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.cs
+++ b/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.cs
@@ -221,6 +221,7 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
       parameterList: (m ?? throw new ArgumentNullException(nameof(m))).GetParameters(),
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
       nullabilityInfoContext: null,
+      nullabilityInfoContextLockObject: null,
 #endif
       typeWithNamespace: typeWithNamespace,
       useDefaultLiteral: useDefaultLiteral
@@ -236,6 +237,22 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     => FormatParameterListCore(
       parameterList: (m ?? throw new ArgumentNullException(nameof(m))).GetParameters(),
       nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      useDefaultLiteral: useDefaultLiteral
+    );
+
+  public static string FormatParameterList(
+    MethodBase m,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool useDefaultLiteral = false
+  )
+    => FormatParameterListCore(
+      parameterList: (m ?? throw new ArgumentNullException(nameof(m))).GetParameters(),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: nullabilityInfoContextLockObject,
       typeWithNamespace: typeWithNamespace,
       useDefaultLiteral: useDefaultLiteral
     );
@@ -250,6 +267,7 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
       parameterList: parameterList ?? throw new ArgumentNullException(nameof(parameterList)),
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
       nullabilityInfoContext: null,
+      nullabilityInfoContextLockObject: null,
 #endif
       typeWithNamespace: typeWithNamespace,
       useDefaultLiteral: useDefaultLiteral
@@ -265,6 +283,22 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     => FormatParameterListCore(
       parameterList: parameterList ?? throw new ArgumentNullException(nameof(parameterList)),
       nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      useDefaultLiteral: useDefaultLiteral
+    );
+
+  public static string FormatParameterList(
+    ParameterInfo[] parameterList,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool useDefaultLiteral = false
+  )
+    => FormatParameterListCore(
+      parameterList: parameterList ?? throw new ArgumentNullException(nameof(parameterList)),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: nullabilityInfoContextLockObject,
       typeWithNamespace: typeWithNamespace,
       useDefaultLiteral: useDefaultLiteral
     );
@@ -274,6 +308,7 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     ParameterInfo[] parameterList,
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
     NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
 #endif
     bool typeWithNamespace = true,
     bool useDefaultLiteral = false
@@ -285,6 +320,7 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
           p,
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
           nullabilityInfoContext: nullabilityInfoContext,
+          nullabilityInfoContextLockObject: nullabilityInfoContextLockObject,
 #endif
           typeWithNamespace: typeWithNamespace,
           useDefaultLiteral: useDefaultLiteral
@@ -297,10 +333,11 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     bool typeWithNamespace = true,
     bool useDefaultLiteral = false
   )
-    => FormatParameter(
+    => FormatParameterCore(
       p: p ?? throw new ArgumentNullException(nameof(p)),
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
       nullabilityInfoContext: null,
+      nullabilityInfoContextLockObject: null,
 #endif
       typeWithNamespace: typeWithNamespace,
       typeWithDeclaringTypeName: true,
@@ -323,6 +360,22 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     => FormatParameter(
       p: p ?? throw new ArgumentNullException(nameof(p)),
       nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: null,
+      typeWithNamespace: typeWithNamespace,
+      useDefaultLiteral: useDefaultLiteral
+    );
+
+  public static string FormatParameter(
+    ParameterInfo p,
+    NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
+    bool typeWithNamespace = true,
+    bool useDefaultLiteral = false
+  )
+    => FormatParameterCore(
+      p: p ?? throw new ArgumentNullException(nameof(p)),
+      nullabilityInfoContext: nullabilityInfoContext,
+      nullabilityInfoContextLockObject: nullabilityInfoContextLockObject,
       typeWithNamespace: typeWithNamespace,
       typeWithDeclaringTypeName: true,
       valueFormatOptions: new(
@@ -335,10 +388,11 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
     );
 #endif
 
-  internal static string FormatParameter(
+  internal static string FormatParameterCore(
     ParameterInfo p,
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
     NullabilityInfoContext? nullabilityInfoContext,
+    object? nullabilityInfoContextLockObject,
 #endif
     bool typeWithNamespace,
     bool typeWithDeclaringTypeName,
@@ -368,6 +422,7 @@ public static partial class CSharpFormatter /* ITypeFormatter */ {
 #pragma warning disable SA1114
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
         nullabilityInfoContext: nullabilityInfoContext,
+        nullabilityInfoContextLockObject: nullabilityInfoContextLockObject,
 #endif
         typeWithNamespace: typeWithNamespace,
         withDeclaringTypeName: typeWithDeclaringTypeName

--- a/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/Generator.cs
+++ b/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/Generator.cs
@@ -985,12 +985,13 @@ public static partial class Generator {
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
     var isDelegate = p.Member == p.Member.DeclaringType?.GetDelegateSignatureMethod();
 #endif
-    var param = CSharpFormatter.FormatParameter(
+    var param = CSharpFormatter.FormatParameterCore(
       p,
 #if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
       nullabilityInfoContext: isDelegate
         ? options.TypeDeclaration.NullabilityInfoContext
         : options.MemberDeclaration.NullabilityInfoContext,
+      nullabilityInfoContextLockObject: null, // TODO
 #endif
       typeWithNamespace: options.ParameterDeclaration.WithNamespace,
       typeWithDeclaringTypeName: options.ParameterDeclaration.WithDeclaringTypeName,

--- a/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/NullabilityInfoContextExtensions.cs
+++ b/src/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/NullabilityInfoContextExtensions.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
+using System;
+using System.Reflection;
+
+namespace Smdn.Reflection.ReverseGenerating;
+
+/// <summary>
+/// Provides extension methods for <see cref="NullabilityInfoContext"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="NullabilityInfoContext"/> internally caches created <see cref="NullabilityInfo"/> using <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>.
+/// This may cause an exception to be thrown if <see cref="NullabilityInfoContext.Create"/> is called concurrently.
+/// So, this class provides extension methods that uses a lock object to lock and then calls <see cref="NullabilityInfoContext.Create"/>.
+/// </remarks>
+internal static class NullabilityInfoContextExtensions {
+  internal static NullabilityInfo Create(this NullabilityInfoContext context, FieldInfo field, object? lockObject)
+  {
+    if (lockObject is null)
+      return context.Create(field);
+
+    lock (lockObject) {
+      return context.Create(field);
+    }
+  }
+
+  internal static NullabilityInfo Create(this NullabilityInfoContext context, PropertyInfo property, object? lockObject)
+  {
+    if (lockObject is null)
+      return context.Create(property);
+
+    lock (lockObject) {
+      return context.Create(property);
+    }
+  }
+
+  internal static NullabilityInfo Create(this NullabilityInfoContext context, ParameterInfo parameter, object? lockObject)
+  {
+    if (lockObject is null)
+      return context.Create(parameter);
+
+    lock (lockObject) {
+      return context.Create(parameter);
+    }
+  }
+
+  internal static NullabilityInfo Create(this NullabilityInfoContext context, EventInfo @event, object? lockObject)
+  {
+    if (lockObject is null)
+      return context.Create(@event);
+
+    lock (lockObject) {
+      return context.Create(@event);
+    }
+  }
+}
+#endif

--- a/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatParameter.cs
+++ b/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatParameter.cs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
+
+#nullable enable annotations
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Smdn.Reflection.ReverseGenerating;
+
+public partial class CSharpFormatterTests {
+  private class TestClassForFormatParameter {
+    public void M(
+      Tuple<string?>? p1,
+      Tuple<string?, string?>? p2,
+      Tuple<string?, string?, string?>? p3,
+      Tuple<string?, string?, string?, string?>? p4,
+      Tuple<string?, string?, string?, string?, string?>? p5,
+      Tuple<string?, string?, string?, string?, string?, string?>? p6,
+      Tuple<string?, string?, string?, string?, string?, string?, string?>? p7,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?>>? p8,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?>>? p9,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?, string?>>? p10,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?, string?, string?>>? p11,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>? p12,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?, string?>>? p13,
+      Tuple<string?, string?, string?, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?, string?, string?>>? p14
+    ) => throw new NotImplementedException();
+  }
+
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task FormatParameter_Concurrent(bool lockCreatingNullabilityInfo)
+  {
+    var parameters = typeof(TestClassForFormatParameter).GetMethod(nameof(TestClassForFormatParameter.M))!.GetParameters();
+
+    Action<NullabilityInfoContext, object?> testAction = new(
+      (ctx, lockObject) => {
+        foreach (var parameter in parameters) {
+          CSharpFormatter.FormatParameter(parameter, ctx, lockObject);
+        }
+      }
+    );
+
+    const int maxNumberOfRepeat = 15;
+
+    if (lockCreatingNullabilityInfo) {
+      await AssertNullabilityInfoContextConcurrentOperationWithLockMustNotThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+    else {
+      await AssertNullabilityInfoContextConcurrentOperationWithoutLockMustThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+  }
+
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task FormatParameterList_OfMethodBase_Concurrent(bool lockCreatingNullabilityInfo)
+  {
+    var method = typeof(TestClassForFormatParameter).GetMethod(nameof(TestClassForFormatParameter.M))!;
+
+    Action<NullabilityInfoContext, object?> testAction = new(
+      (ctx, lockObject) => CSharpFormatter.FormatParameterList(method, ctx, lockObject)
+    );
+
+    const int maxNumberOfRepeat = 15;
+
+    if (lockCreatingNullabilityInfo) {
+      await AssertNullabilityInfoContextConcurrentOperationWithLockMustNotThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+    else {
+      await AssertNullabilityInfoContextConcurrentOperationWithoutLockMustThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+  }
+
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task FormatParameterList_OfArrayOfParameterInfo_Concurrent(bool lockCreatingNullabilityInfo)
+  {
+    var parameters = typeof(TestClassForFormatParameter).GetMethod(nameof(TestClassForFormatParameter.M))!.GetParameters();
+
+    Action<NullabilityInfoContext, object?> testAction = new(
+      (ctx, lockObject) => CSharpFormatter.FormatParameterList(parameters, ctx, lockObject)
+    );
+
+    const int maxNumberOfRepeat = 15;
+
+    if (lockCreatingNullabilityInfo) {
+      await AssertNullabilityInfoContextConcurrentOperationWithLockMustNotThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+    else {
+      await AssertNullabilityInfoContextConcurrentOperationWithoutLockMustThrowExceptionAsync(
+        testAction,
+        maxNumberOfRepeat
+      ).ConfigureAwait(false);
+    }
+  }
+}
+#endif

--- a/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatTypeName.cs
+++ b/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.FormatTypeName.cs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2023 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+#if SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT
+
+#nullable enable annotations
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Smdn.Reflection.ReverseGenerating;
+
+public partial class CSharpFormatterTests {
+#pragma warning disable CS0649
+  private class C {
+    public string? F0;
+    public string? F1;
+    public string? F2;
+    public string? F3;
+    public string? F4;
+    public string? F5;
+    public string? F6;
+    public string? F7;
+    public string? F8;
+    public string? F9;
+
+    public string? P0 { get; set; }
+    public string? P1 { get; set; }
+    public string? P2 { get; set; }
+    public string? P3 { get; set; }
+    public string? P4 { get; set; }
+    public string? P5 { get; set; }
+    public string? P6 { get; set; }
+    public string? P7 { get; set; }
+    public string? P8 { get; set; }
+    public string? P9 { get; set; }
+
+    public event EventHandler? E0;
+    public event EventHandler? E1;
+    public event EventHandler? E2;
+    public event EventHandler? E3;
+    public event EventHandler? E4;
+    public event EventHandler? E5;
+    public event EventHandler? E6;
+    public event EventHandler? E7;
+    public event EventHandler? E8;
+    public event EventHandler? E9;
+
+    public void M(
+      string? p0,
+      string? p1,
+      string? p2,
+      string? p3,
+      string? p4,
+      string? p5,
+      string? p6,
+      string? p7,
+      string? p8,
+      string? p9
+    ) => throw new NotImplementedException();
+  }
+#pragma warning restore CS0649
+
+  [Test]
+  public Task FormatTypeName_FieldInfo_Concurrent()
+    => FormatTypeName_Concurrent(
+      typeof(C),
+      typeof(C).GetField(nameof(C.F0)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F0)}"),
+      typeof(C).GetField(nameof(C.F1)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F1)}"),
+      typeof(C).GetField(nameof(C.F2)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F2)}"),
+      typeof(C).GetField(nameof(C.F3)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F3)}"),
+      typeof(C).GetField(nameof(C.F4)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F4)}"),
+      typeof(C).GetField(nameof(C.F5)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F5)}"),
+      typeof(C).GetField(nameof(C.F6)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F6)}"),
+      typeof(C).GetField(nameof(C.F7)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F7)}"),
+      typeof(C).GetField(nameof(C.F8)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F8)}"),
+      typeof(C).GetField(nameof(C.F9)) ?? throw new InvalidOperationException($"field not found: {nameof(C.F9)}")
+    );
+
+  [Test]
+  public Task FormatTypeName_PropertyInfo_Concurrent()
+    => FormatTypeName_Concurrent(
+      typeof(C),
+      typeof(C).GetProperty(nameof(C.P0)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P0)}"),
+      typeof(C).GetProperty(nameof(C.P1)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P1)}"),
+      typeof(C).GetProperty(nameof(C.P2)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P2)}"),
+      typeof(C).GetProperty(nameof(C.P3)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P3)}"),
+      typeof(C).GetProperty(nameof(C.P4)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P4)}"),
+      typeof(C).GetProperty(nameof(C.P5)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P5)}"),
+      typeof(C).GetProperty(nameof(C.P6)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P6)}"),
+      typeof(C).GetProperty(nameof(C.P7)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P7)}"),
+      typeof(C).GetProperty(nameof(C.P8)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P8)}"),
+      typeof(C).GetProperty(nameof(C.P9)) ?? throw new InvalidOperationException($"property not found: {nameof(C.P9)}")
+    );
+
+  [Test]
+  public Task FormatTypeName_EventInfo_Concurrent()
+    => FormatTypeName_Concurrent(
+      typeof(C),
+      typeof(C).GetEvent(nameof(C.E0)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E0)}"),
+      typeof(C).GetEvent(nameof(C.E1)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E1)}"),
+      typeof(C).GetEvent(nameof(C.E2)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E2)}"),
+      typeof(C).GetEvent(nameof(C.E3)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E3)}"),
+      typeof(C).GetEvent(nameof(C.E4)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E4)}"),
+      typeof(C).GetEvent(nameof(C.E5)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E5)}"),
+      typeof(C).GetEvent(nameof(C.E6)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E6)}"),
+      typeof(C).GetEvent(nameof(C.E7)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E7)}"),
+      typeof(C).GetEvent(nameof(C.E8)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E8)}"),
+      typeof(C).GetEvent(nameof(C.E9)) ?? throw new InvalidOperationException($"event not found: {nameof(C.E9)}")
+    );
+
+  [Test]
+  public Task FormatTypeName_ParameterInfo_Concurrent()
+    => FormatTypeName_Concurrent(
+      typeof(C),
+      typeof(C).GetMethod(nameof(C.M))!.GetParameters()
+    );
+
+  private async Task FormatTypeName_Concurrent<TMemberInfo>(Type declaringTypeOfTargets, params TMemberInfo[] targets)
+    where TMemberInfo : class
+  {
+    Func<object, NullabilityInfoContext, string> formatTypeName;
+
+    if (typeof(TMemberInfo) == typeof(FieldInfo))
+      formatTypeName = new Func<object, NullabilityInfoContext, string>(static (f, ctx) => CSharpFormatter.FormatTypeName((FieldInfo)f, ctx));
+    else if (typeof(TMemberInfo) == typeof(PropertyInfo))
+      formatTypeName = new Func<object, NullabilityInfoContext, string>(static (p, ctx) => CSharpFormatter.FormatTypeName((PropertyInfo)p, ctx));
+    else if (typeof(TMemberInfo) == typeof(EventInfo))
+      formatTypeName = new Func<object, NullabilityInfoContext, string>(static (ev, ctx) => CSharpFormatter.FormatTypeName((EventInfo)ev, ctx));
+    else if (typeof(TMemberInfo) == typeof(ParameterInfo))
+      formatTypeName = new Func<object, NullabilityInfoContext, string>(static (para, ctx) => CSharpFormatter.FormatTypeName((ParameterInfo)para, ctx));
+    else
+      throw new NotSupportedException();
+
+    const int maxNumberOfRepeat = 20;
+    var participantCount = Environment.ProcessorCount * 2;
+    var expectedExceptionThrown = false;
+
+    for (var n = 0; n < maxNumberOfRepeat; n++) {
+      using var barrier = new Barrier(participantCount);
+      using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10.0));
+
+      var parallelOptions = new ParallelOptions() {
+        MaxDegreeOfParallelism = participantCount,
+        CancellationToken = cancellationTokenSource.Token,
+      };
+
+      // confirms that an ArgumentException or IndexOutOfRangeException is thrown when
+      // NullabilityInfoContext.Create() is called in a concurrency.
+      var ctx = new NullabilityInfoContext();
+
+      try {
+        await Parallel.ForEachAsync(Enumerable.Range(0, participantCount), parallelOptions, (_, cancellationToken) => {
+          barrier.SignalAndWait(cancellationToken);
+
+          foreach (var target in targets) {
+            formatTypeName(target, ctx);
+          }
+
+          return default; // ValueTask
+        });
+      }
+      catch (ArgumentException ex) when (
+        (ex.Message ?? string.Empty).Contains(declaringTypeOfTargets.FullName!, StringComparison.Ordinal)
+      ) {
+        // excepted exception: "An item with the same key has already been added."
+        expectedExceptionThrown = true;
+      }
+      catch (IndexOutOfRangeException) {
+        // excepted exception: "Index was outside the bounds of the array."
+        expectedExceptionThrown = true;
+      }
+
+      if (expectedExceptionThrown)
+        break;
+    }
+
+    if (!expectedExceptionThrown)
+      Assert.Warn($"The operation succeeded unexpectedly. ({formatTypeName.Method.Name}");
+  }
+}
+#endif // SYSTEM_REFLECTION_NULLABILITYINFOCONTEXT

--- a/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.cs
+++ b/tests/Smdn.Reflection.ReverseGenerating/Smdn.Reflection.ReverseGenerating/CSharpFormatter.cs
@@ -32,7 +32,7 @@ public class CCloseGeneric : CGeneric<int, string> {
 }
 
 [TestFixture]
-public class CSharpFormatterTests {
+public partial class CSharpFormatterTests {
   [TestCase(typeof(int), "int")]
   [TestCase(typeof(int[]), "int[]")]
   [TestCase(typeof(int[,]), "int[,]")]


### PR DESCRIPTION
### Fixes issue
<!-- Link the number of the issue(s), if any, that will be fixed or resolved by this pull request. -->
<!-- このPull Requestによって修正または解決されるIssueがある場合は、その番号を記入してリンクしてください。-->
Fixes #20
